### PR TITLE
Adapt role names for "service-http-proxy"

### DIFF
--- a/web.yml
+++ b/web.yml
@@ -15,7 +15,7 @@
 
   roles:
     - role: apache
-    - role: dehydrated
+    - role: ansible-role-dehydrated
 
 
   tasks:

--- a/web.yml
+++ b/web.yml
@@ -21,14 +21,14 @@
   tasks:
     - name: Setup proxy site md.freifunk.net
       include_role:
-        name: setup-http-site-proxy
+        name: service-http-proxy
       vars:
         site_name: md.freifunk.net
         proxy_port: 1234
 
     - name: Setup proxy site grafana.md.freifunk.net
       include_role:
-        name: setup-http-site-proxy
+        name: service-http-proxy
       vars:
         site_name: grafana.md.freifunk.net
         proxy_port: 3000


### PR DESCRIPTION
The role has been renamed without adapting the playbooks.